### PR TITLE
Factor out some of the sparse internals to enable more re-use.

### DIFF
--- a/include/tatami/base/sparse/CompressedSparseMatrix.hpp
+++ b/include/tatami/base/sparse/CompressedSparseMatrix.hpp
@@ -503,14 +503,13 @@ private:
         SecondaryWorkspace(Index_ max_index, const IndexStorage_& idx, const PointerStorage_& idp, Args_&&... args) :
             state(max_index, idx, idp, std::forward<Args_>(args)...) {}
 
-        sparse::SimpleSecondaryExtractionWorkspace<Index_, index_type, indptr_type> state;
+        sparse::SimpleSecondaryExtractionWorkspace<Index_, index_type, indptr_type, Modifier> state;
         Index_ previous_request = 0;
-        Modifier mod;
     };
 
     template<class Store_>
     void secondary_dimension_above(Index_ secondary, Index_ primary, Index_ index_primary, SecondaryWorkspace& work, Store_& output) const {
-        auto curdex = work.state.search_above(secondary, primary, index_primary, indices, indptrs, work.mod);
+        auto curdex = work.state.search_above(secondary, primary, index_primary, indices, indptrs);
         if (secondary == curdex) { // assuming secondary < max_index, of course.
             add_to_store(primary, work.state.current_indptrs[index_primary], output);
         } else {
@@ -520,7 +519,7 @@ private:
 
     template<class Store_>
     void secondary_dimension_below(Index_ secondary, Index_ primary, Index_ index_primary, SecondaryWorkspace& work, Store_& output) const {
-        auto curdex = work.state.search_below(secondary, primary, index_primary, indices, indptrs, work.mod);
+        auto curdex = work.state.search_below(secondary, primary, index_primary, indices, indptrs);
         if (secondary == curdex) { // assuming secondary < max_index, of course.
             add_to_store(primary, work.state.current_indptrs[index_primary], output);
         } else {

--- a/include/tatami/base/sparse/CompressedSparseMatrix.hpp
+++ b/include/tatami/base/sparse/CompressedSparseMatrix.hpp
@@ -3,6 +3,7 @@
 
 #include "../Matrix.hpp"
 #include "../utils.hpp"
+#include "utils.hpp"
 
 #include <vector>
 #include <algorithm>
@@ -482,105 +483,36 @@ private:
     /*************************************
      ******* Secondary extraction ********
      *************************************/
-#ifdef DEBUG
-public:
-#else
 private:
-#endif
-
     struct SecondaryWorkspace {
-        typedef typename std::remove_reference<decltype(std::declval<IndexStorage_>()[0])>::type index_type;
-        typedef typename std::remove_reference<decltype(std::declval<PointerStorage_>()[0])>::type indptr_type;
+        typedef sparse::Stored<IndexStorage_> index_type;
+        typedef sparse::Stored<PointerStorage_> indptr_type;
 
+    public:
+        struct Modifier {
+            static void increment(indptr_type& ptr, const IndexStorage_&, const indptr_type&) { ++ptr; }
+            static void decrement(indptr_type& ptr, const IndexStorage_&, const indptr_type&) { --ptr; }
+            static indptr_type get(indptr_type ptr) { return ptr; }
+            static void set(indptr_type& ptr, indptr_type val) { ptr = val; }
+        };
+
+    public:
         SecondaryWorkspace() = default;
 
-        SecondaryWorkspace(Index_ max_index, const IndexStorage_& idx, const PointerStorage_& idp, Index_ start, Index_ length) :
-            current_indptrs(idp.begin() + start, idp.begin() + start + length), current_indices(length)
-        {
-            /* Here, the general idea is to store a local copy of the actual
-             * row indices (for CSC matrices; column indices, for CSR matrices)
-             * so that we don't have to keep on doing cache-unfriendly look-ups
-             * for the indices based on the pointers that we do have. This assumes
-             * that the density is so low that updates to the local indices are
-             * rare relative to the number of comparisons to those same indices.
-             * Check out the `secondary_dimension()` function for how this is used.
-             */
-            auto idpIt = idp.begin() + start;
-            for (Index_ i = 0; i < length; ++i, ++idpIt) {
-                current_indices[i] = (*idpIt < *(idpIt + 1) ? idx[*idpIt] : max_index);
-            }
-            return;
-        } 
+        template<typename ... Args_>
+        SecondaryWorkspace(Index_ max_index, const IndexStorage_& idx, const PointerStorage_& idp, Args_&&... args) :
+            state(max_index, idx, idp, std::forward<Args_>(args)...) {}
 
-        SecondaryWorkspace(Index_ max_index, const IndexStorage_& idx, const PointerStorage_& idp) :
-            SecondaryWorkspace(max_index, idx, idp, static_cast<Index_>(0), idp.size() - 1) {}
-
-        SecondaryWorkspace(Index_ max_index, const IndexStorage_& idx, const PointerStorage_& idp, const Index_* subset, Index_ length) :
-            current_indptrs(length), current_indices(length)
-        {
-            for (Index_ i0 = 0; i0 < length; ++i0) {
-                auto i = subset[i0];
-                current_indptrs[i0] = idp[i];
-                current_indices[i0] = (idp[i] < idp[i + 1] ? idx[idp[i]] : max_index);
-            }
-            return;
-        } 
-
+        sparse::SimpleSecondaryExtractionWorkspace<Index_, index_type, indptr_type> state;
         Index_ previous_request = 0;
-        std::vector<indptr_type> current_indptrs; // the current position of the pointer
-
-        // The current index being pointed to, i.e., current_indices[0] <= indices[current_ptrs[0]]. 
-        // If current_ptrs[0] is out of range, the current index is instead set to the maximum index
-        // (e.g., max rows for CSC matrices).
-        std::vector<index_type> current_indices;
+        Modifier mod;
     };
 
-private:
     template<class Store_>
     void secondary_dimension_above(Index_ secondary, Index_ primary, Index_ index_primary, SecondaryWorkspace& work, Store_& output) const {
-        auto& curdex = work.current_indices[index_primary];
-        auto& curptr = work.current_indptrs[index_primary];
-
-        // Remember that we already store the index corresponding to the current indptr.
-        // So, we only need to do more work if the request is greater than that index.
-        if (secondary > curdex) {
-            auto max_index = max_secondary_index();
-            auto limit = indptrs[primary + 1];
-
-            // Having a peek at the index of the next non-zero
-            // element; maybe we're lucky enough that the requested
-            // index is below this, as would be the case for
-            // consecutive or near-consecutive accesses.
-            ++curptr;
-            if (curptr < limit) {
-                auto candidate = indices[curptr];
-                if (candidate >= secondary) {
-                    curdex = candidate;
-
-                } else if (secondary + 1 == max_index) {
-                    // Special case if the requested index is at the end of the matrix,
-                    // in which case we can just jump there directly rather than 
-                    // doing an unnecessary binary search.
-                    curptr = limit - 1;
-                    if (indices[curptr] == secondary) {
-                        curdex = indices[curptr];
-                    } else {
-                        ++curptr;
-                        curdex = max_index;
-                    }
-
-                } else {
-                    // Otherwise we need to search indices above the existing position.
-                    curptr = std::lower_bound(indices.begin() + curptr, indices.begin() + limit, secondary) - indices.begin();
-                    curdex = (curptr < limit ? indices[curptr] : max_index);
-                }
-            } else {
-                curdex = max_index;
-            }
-        } 
-
+        auto curdex = work.state.search_above(secondary, primary, index_primary, indices, indptrs, work.mod);
         if (secondary == curdex) { // assuming secondary < max_index, of course.
-            add_to_store(primary, curptr, output);
+            add_to_store(primary, work.state.current_indptrs[index_primary], output);
         } else {
             output.skip(primary);
         }
@@ -588,28 +520,9 @@ private:
 
     template<class Store_>
     void secondary_dimension_below(Index_ secondary, Index_ primary, Index_ index_primary, SecondaryWorkspace& work, Store_& output) const {
-        auto& curdex = work.current_indices[index_primary];
-        auto& curptr = work.current_indptrs[index_primary];
-
-        if (secondary < curdex) {
-            auto limit = indptrs[primary + 1];
-            if (indptrs[primary] < limit) {
-                if (secondary == 0) {
-                    // Special case if the requested index is at the end of the matrix,
-                    // in which case we can just jump there directly rather than 
-                    // doing an unnecessary binary search.
-                    curptr = indptrs[primary];
-                    curdex = indices[curptr];
-                } else {
-                    // Otherwise, searching indices below the existing position.
-                    curptr = std::lower_bound(indices.begin() + indptrs[primary], indices.begin() + curptr, secondary) - indices.begin();
-                    curdex = (curptr < limit ? indices[curptr] : max_secondary_index());
-                }
-            }
-        }
-
+        auto curdex = work.state.search_below(secondary, primary, index_primary, indices, indptrs, work.mod);
         if (secondary == curdex) { // assuming secondary < max_index, of course.
-            add_to_store(primary, curptr, output);
+            add_to_store(primary, work.state.current_indptrs[index_primary], output);
         } else {
             output.skip(primary);
         }
@@ -699,12 +612,7 @@ private:
         return;
     }
 
-#ifdef DEBUG
-public:
-#else
 private:
-#endif
-
     template<DimensionSelectionType selection_, bool sparse_>
     struct SecondaryExtractorBase : public CompressedExtractorBase<!row_, selection_, sparse_> {
         template<typename ...Args_>

--- a/include/tatami/base/sparse/SemiCompressedSparseMatrix.hpp
+++ b/include/tatami/base/sparse/SemiCompressedSparseMatrix.hpp
@@ -491,11 +491,11 @@ private:
                 ptr.pointer = copy;
             }
 
-            indptr_type get(const Position& ptr) const {
+            static indptr_type get(const Position& ptr) {
                 return ptr.pointer;
             }
 
-            void set(Position& ptr, indptr_type val) const {
+            static void set(Position& ptr, indptr_type val) {
                 ptr.pointer = val;
                 ptr.scanned = false;
                 ptr.count = 0;
@@ -510,13 +510,12 @@ private:
             state(max_index, idx, idp, std::forward<Args_>(args)...) {}
 
         Index_ previous_request = 0;
-        sparse::SimpleSecondaryExtractionWorkspace<Index_, index_type, Position> state;
-        Modifier mod;
+        sparse::SimpleSecondaryExtractionWorkspace<Index_, index_type, Position, Modifier> state;
     };
 
     template<class Store_>
     void secondary_dimension_above(Index_ secondary, Index_ primary, Index_ index_primary, SecondaryWorkspace& work, Store_& output) const {
-        auto curdex = work.state.search_above(secondary, primary, index_primary, indices, indptrs, work.mod);
+        auto curdex = work.state.search_above(secondary, primary, index_primary, indices, indptrs);
         if (secondary == curdex) { // assuming secondary < max_index, of course.
             auto& curptr = work.state.current_indptrs[index_primary];
             work.update_secondary_position(curptr, indices, indptrs[primary + 1]);
@@ -528,7 +527,7 @@ private:
 
     template<class Store_>
     void secondary_dimension_below(Index_ secondary, Index_ primary, Index_ index_primary, SecondaryWorkspace& work, Store_& output) const {
-        auto curdex = work.state.search_below(secondary, primary, index_primary, indices, indptrs, work.mod);
+        auto curdex = work.state.search_below(secondary, primary, index_primary, indices, indptrs);
         if (secondary == curdex) { // assuming secondary < max_index, of course.
             auto& curptr = work.state.current_indptrs[index_primary];
             work.update_secondary_position(curptr, indices, indptrs[primary + 1]);

--- a/include/tatami/base/sparse/utils.hpp
+++ b/include/tatami/base/sparse/utils.hpp
@@ -1,0 +1,190 @@
+#ifndef TATAMI_SPARSE_UTILS_HPP
+#define TATAMI_SPARSE_UTILS_HPP
+
+#include <vector>
+
+namespace tatami {
+
+namespace sparse {
+
+template<class Storage_>
+using Stored = typename std::remove_reference<decltype(std::declval<Storage_>()[0])>::type;
+
+template<typename StoredIndex_> 
+struct SecondaryExtractionWorkspaceBase {
+private:
+    StoredIndex_ max_index;
+
+public:
+    SecondaryExtractionWorkspaceBase(StoredIndex_ mi) : max_index(mi) {}
+
+    SecondaryExtractionWorkspaceBase() = default;
+
+public:
+    template<typename Index_, class IndexStorage_, class PointerStorage_, class SuperPointer_, class SuperPointerModifier_>
+    void search_above(StoredIndex_ secondary, Index_ primary, const IndexStorage_& indices, const PointerStorage_& indptrs, StoredIndex_& curdex, SuperPointer_& curptr, SuperPointerModifier_& shifter) const {
+        // Skipping if the curdex (corresponding to curptr) is already higher
+        // than secondary.  So, we only need to do more work if the request is
+        // greater than the stored index.  This also catches cases where we're
+        // at the end of the dimension, as curdex is set to max_index.
+        if (secondary <= curdex) {
+            return;
+        }
+
+        auto limit = indptrs[primary + 1];
+
+        // Special case if the requested index is at the end of the matrix, in
+        // which case we can just jump there directly rather than doing an
+        // unnecessary binary search. Note that 'limit - 1' is always available
+        // as this dimension element should be non-empty if secondary > curdex.
+        if (secondary + 1 == max_index) {
+            if (indices[limit - 1] == secondary) {
+                shifter.set(curptr, limit); // don't set directly to 'limit - 1' as this won't be the start of the run in semi-compressed mode.
+                shifter.decrement(curptr, indices, indptrs[primary]);
+                curdex = secondary;
+            } else {
+                shifter.set(curptr, limit);
+                curdex = max_index;
+            }
+            return;
+        }
+
+        // Having a peek at the index of the next non-zero element; maybe we're
+        // lucky enough that the requested index is below this, as would be the
+        // case for consecutive or near-consecutive accesses.
+        shifter.increment(curptr, indices, limit);
+        auto raw_ptr = shifter.get(curptr);
+        if (raw_ptr == limit) {
+            curdex = max_index;
+            return;
+        }
+
+        auto candidate = indices[raw_ptr];
+        if (candidate >= secondary) {
+            curdex = candidate;
+            return;
+        }
+
+        // Otherwise we need to search indices above the existing position.
+        ++raw_ptr;
+        Stored<PointerStorage_> next_ptr = std::lower_bound(indices.begin() + raw_ptr, indices.begin() + limit, secondary) - indices.begin();
+        shifter.set(curptr, next_ptr);
+        curdex = (next_ptr != limit ? indices[next_ptr] : max_index);
+    }
+
+    template<typename Index_, class IndexStorage_, class PointerStorage_, class SuperPointer_, class SuperPointerModifier_>
+    void search_below(StoredIndex_ secondary, Index_ primary, const IndexStorage_& indices, const PointerStorage_& indptrs, StoredIndex_& curdex, SuperPointer_& curptr, SuperPointerModifier_& shifter) const {
+        if (secondary == curdex) {
+            return;
+        }
+
+        auto lower_limit = indptrs[primary];
+        if (shifter.get(curptr) == lower_limit) {
+            return;
+        }
+
+        // Special case if the requested index is at the end of the matrix,
+        // in which case we can just jump there directly rather than 
+        // doing an unnecessary binary search.
+        if (secondary == 0) {
+            auto first_ptr = indptrs[primary];
+            shifter.set(curptr, first_ptr);
+            curdex = indices[first_ptr];
+            return;
+        }
+
+        // Having a peek at the index of the next non-zero element and
+        // seeing whether we stop searching, as would be the case for
+        // consecutive or near-consecutive accesses.
+        shifter.decrement(curptr, indices, lower_limit);
+        auto raw_ptr = shifter.get(curptr);
+        auto candidate = indices[raw_ptr];
+        if (candidate < secondary) {
+            shifter.increment(curptr, indices, indptrs[primary + 1]); // oops, went too far; undo the change.
+            return;
+        }
+
+        curdex = candidate; 
+        if (candidate == secondary) {
+            return;
+        }
+
+        // Otherwise, searching indices below the existing position.
+        Stored<PointerStorage_> next_ptr =  std::lower_bound(indices.begin() + lower_limit, indices.begin() + raw_ptr, secondary) - indices.begin();
+        shifter.set(curptr, next_ptr);
+        curdex = (next_ptr != indptrs[primary + 1] ? indices[next_ptr] : max_index);
+    }
+};
+
+template<typename Index_, typename StoredIndex_, class SuperPointer_>
+struct SimpleSecondaryExtractionWorkspace {
+public:
+    SimpleSecondaryExtractionWorkspace() = default;
+
+    template<class IndexStorage_, class PointerStorage_>
+    SimpleSecondaryExtractionWorkspace(StoredIndex_ max_index, const IndexStorage_& idx, const PointerStorage_& idp, Index_ start, Index_ length) :
+        base(max_index), current_indices(length), current_indptrs(idp.begin() + start, idp.begin() + start + length)
+    {
+        /* Here, the general idea is to store a local copy of the actual
+         * row indices (for CSC matrices; column indices, for CSR matrices)
+         * so that we don't have to keep on doing cache-unfriendly look-ups
+         * for the indices based on the pointers that we do have. This assumes
+         * that the density is so low that updates to the local indices are
+         * rare relative to the number of comparisons to those same indices.
+         * Check out the `secondary_dimension()` function for how this is used.
+         */
+        auto idpIt = idp.begin() + start;
+        for (Index_ i = 0; i < length; ++i, ++idpIt) {
+            current_indices[i] = (*idpIt < *(idpIt + 1) ? idx[*idpIt] : max_index);
+        }
+        return;
+    } 
+
+    template<class IndexStorage_, class PointerStorage_>
+    SimpleSecondaryExtractionWorkspace(StoredIndex_ max_index, const IndexStorage_& idx, const PointerStorage_& idp) :
+        SimpleSecondaryExtractionWorkspace(max_index, idx, idp, static_cast<Index_>(0), static_cast<Index_>(idp.size() - 1)) {}
+
+    template<class IndexStorage_, class PointerStorage_>
+    SimpleSecondaryExtractionWorkspace(StoredIndex_ max_index, const IndexStorage_& idx, const PointerStorage_& idp, const Index_* subset, Index_ length) :
+        base(max_index), current_indices(length), current_indptrs(length)
+    {
+        for (Index_ i0 = 0; i0 < length; ++i0) {
+            auto i = subset[i0];
+            current_indptrs[i0] = idp[i];
+            current_indices[i0] = (idp[i] < idp[i + 1] ? idx[idp[i]] : max_index);
+        }
+        return;
+    }
+
+public:
+    SecondaryExtractionWorkspaceBase<StoredIndex_> base;
+
+    // The current position of the pointer at each primary element.
+    std::vector<SuperPointer_> current_indptrs; 
+
+    // The current index being pointed to, i.e., current_indices[0] <= indices[current_ptrs[0]]. 
+    // If current_ptrs[0] is out of range, the current index is instead set to the maximum index
+    // (e.g., max rows for CSC matrices).
+    std::vector<StoredIndex_> current_indices;
+
+public:
+    template<class IndexStorage_, class PointerStorage_, class SuperPointerModifier_>
+    StoredIndex_ search_above(StoredIndex_ secondary, Index_ primary, Index_ index_primary, const IndexStorage_& indices, const PointerStorage_& indptrs, SuperPointerModifier_& shifter) {
+        auto& curdex = current_indices[index_primary];
+        base.search_above(secondary, primary, indices, indptrs, curdex, current_indptrs[index_primary], shifter);
+        return curdex;
+    }
+
+    template<class IndexStorage_, class PointerStorage_, class SuperPointerModifier_>
+    StoredIndex_ search_below(StoredIndex_ secondary, Index_ primary, Index_ index_primary, const IndexStorage_& indices, const PointerStorage_& indptrs, SuperPointerModifier_& shifter) {
+        auto& curdex = current_indices[index_primary];
+        base.search_below(secondary, primary, indices, indptrs, curdex, current_indptrs[index_primary], shifter);
+        return curdex;
+    }
+};
+
+}
+
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(
     src/base/arith_scalar_helpers.cpp
     src/base/math_helpers.cpp
 
+    src/sparse/utils.cpp
+
     src/stats/sums.cpp
     src/stats/variances.cpp
     src/stats/medians.cpp

--- a/tests/src/base/SemiCompressedSparseMatrix.cpp
+++ b/tests/src/base/SemiCompressedSparseMatrix.cpp
@@ -255,3 +255,35 @@ INSTANTIATE_TEST_CASE_P(
     )
 );
 
+/*************************************
+ *************************************/
+
+TEST(SemiCompressedSparseMatrix, ExtremeCounting) {
+    // Checking for correct counting of duplicates at the extremes.
+    std::vector<int> indices {
+        2, 2, 2, 8, 11, 11, 12,
+        3, 4, 4, 7, 10, 10, 12, 15, 18, 18, 18, 18,
+        0, 0, 0, 0,  1,  4,  8,  8,  8, 14, 14
+    };
+
+    std::vector<size_t> indptrs {
+        0,
+        7,
+        19,
+        30
+    };
+
+    tatami::SemiCompressedSparseColumnMatrix<double, int> mat(19, 3, indices, indptrs);
+
+    auto wrk = mat.dense_row();
+    {
+        std::vector<double> temp{ 0, 0, 4 };
+        EXPECT_EQ(wrk->fetch(0), temp);
+
+        temp = std::vector<double>{ 0, 4, 0 };
+        EXPECT_EQ(wrk->fetch(18), temp);
+
+        temp = std::vector<double>{ 0, 0, 4 }; // jumping back to the start.
+        EXPECT_EQ(wrk->fetch(0), temp);
+    }
+}

--- a/tests/src/sparse/utils.cpp
+++ b/tests/src/sparse/utils.cpp
@@ -1,0 +1,271 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <memory>
+
+#include "tatami/base/sparse/utils.hpp"
+
+struct SimpleModifier {
+    static void increment(size_t& ptr, const std::vector<int>&, const size_t&) { ++ptr; }
+    static void decrement(size_t& ptr, const std::vector<int>&, const size_t&) { --ptr; }
+    static size_t get(size_t ptr) { return ptr; }
+    static void set(size_t& ptr, size_t val) { ptr = val; }
+};
+
+TEST(SecondaryExtractionWorkspaceBase, Increment) {
+    tatami::sparse::SecondaryExtractionWorkspaceBase<int, SimpleModifier> test(19);
+
+    std::vector<int> indices {
+        0, 5, 6, 9, 10,
+        1, 8, 12, 18,
+        5, 9, 10, 12, 13, 15, 17
+    };
+
+    std::vector<size_t> indptrs {
+        0,
+        5,
+        9,
+        16
+    };
+
+    {
+        int curdex = 0;
+        size_t curptr = 0;
+        test.search_above(0, 0, indices, indptrs, curdex, curptr); // no-op.
+        EXPECT_EQ(curdex, 0);
+        EXPECT_EQ(curptr, 0);
+
+        test.search_above(1, 0, indices, indptrs, curdex, curptr); // consecutive increase.
+        EXPECT_EQ(curdex, 5);
+        EXPECT_EQ(curptr, 1);
+
+        test.search_above(3, 0, indices, indptrs, curdex, curptr); // no-op, curdex is still above the requested secondary index.
+        EXPECT_EQ(curdex, 5);
+        EXPECT_EQ(curptr, 1);
+
+        test.search_above(5, 0, indices, indptrs, curdex, curptr); // hit!
+        EXPECT_EQ(curdex, 5);
+        EXPECT_EQ(curptr, 1);
+
+        test.search_above(6, 0, indices, indptrs, curdex, curptr); // consecutive increase.
+        EXPECT_EQ(curdex, 6);
+        EXPECT_EQ(curptr, 2);
+    }
+
+    {
+        int curdex = 1;
+        size_t curptr = 5;
+        test.search_above(0, 1, indices, indptrs, curdex, curptr); // no-op, curdex is still above the requested secondary index.
+        EXPECT_EQ(curdex, 1);
+        EXPECT_EQ(curptr, 5);
+
+        test.search_above(15, 1, indices, indptrs, curdex, curptr); // big jump, triggers binary search.
+        EXPECT_EQ(curdex, 18);
+        EXPECT_EQ(curptr, 8);
+    }
+
+    {
+        int curdex = 1;
+        size_t curptr = 5;
+        test.search_above(18, 1, indices, indptrs, curdex, curptr); // direct big jump to end.
+        EXPECT_EQ(curdex, 18);
+        EXPECT_EQ(curptr, 8);
+    }
+
+    {
+        int curdex = 5;
+        size_t curptr = 9;
+        test.search_above(11, 2, indices, indptrs, curdex, curptr); // big jump (1)
+        EXPECT_EQ(curdex, 12);
+        EXPECT_EQ(curptr, 12);
+
+        test.search_above(17, 2, indices, indptrs, curdex, curptr); // big jump (2)
+        EXPECT_EQ(curdex, 17);
+        EXPECT_EQ(curptr, 15);
+    }
+
+    {
+        int curdex = 5;
+        size_t curptr = 9;
+        test.search_above(18, 2, indices, indptrs, curdex, curptr); // big jump to end, but without a match.
+        EXPECT_EQ(curdex, 19);
+        EXPECT_EQ(curptr, 16);
+    }
+}
+
+TEST(SecondaryExtractionWorkspaceBase, Decrement) {
+    tatami::sparse::SecondaryExtractionWorkspaceBase<int, SimpleModifier> test(19);
+
+    std::vector<int> indices {
+        2, 8, 11, 12, 18,
+        3, 4, 7, 10, 12, 15,  
+        0, 1, 4, 8, 14
+    };
+
+    std::vector<size_t> indptrs {
+        0,
+        5,
+        11,
+        16
+    };
+
+    {
+        int curdex = 18;
+        size_t curptr = 4;
+        test.search_below(18, 0, indices, indptrs, curdex, curptr); // no-op.
+        EXPECT_EQ(curdex, 18);
+        EXPECT_EQ(curptr, 4);
+
+        test.search_below(15, 0, indices, indptrs, curdex, curptr); // no-op, curdex is still the lower bound.
+        EXPECT_EQ(curdex, 18);
+        EXPECT_EQ(curptr, 4);
+
+        test.search_below(12, 0, indices, indptrs, curdex, curptr); // decrease.
+        EXPECT_EQ(curdex, 12);
+        EXPECT_EQ(curptr, 3);
+
+        test.search_below(11, 0, indices, indptrs, curdex, curptr); // another consecutive decrease.
+        EXPECT_EQ(curdex, 11);
+        EXPECT_EQ(curptr, 2);
+
+        test.search_below(9, 0, indices, indptrs, curdex, curptr); // no-op, curdex is still the lower bound.
+        EXPECT_EQ(curdex, 11);
+        EXPECT_EQ(curptr, 2);
+
+        test.search_below(1, 0, indices, indptrs, curdex, curptr); // big jump.
+        EXPECT_EQ(curdex, 2);
+        EXPECT_EQ(curptr, 0);
+    }
+
+    {
+        int curdex = 19;
+        size_t curptr = 11;
+        test.search_below(18, 1, indices, indptrs, curdex, curptr); // no-op, still the lower bound..
+        EXPECT_EQ(curdex, 19);
+        EXPECT_EQ(curptr, 11);
+
+        test.search_below(9, 1, indices, indptrs, curdex, curptr); // big jump (1).
+        EXPECT_EQ(curdex, 10);
+        EXPECT_EQ(curptr, 8);
+
+        test.search_below(1, 1, indices, indptrs, curdex, curptr); // big jump (2).
+        EXPECT_EQ(curdex, 3);
+        EXPECT_EQ(curptr, 5);
+    }
+
+    {
+        int curdex = 19;
+        size_t curptr = 11;
+        test.search_below(0, 1, indices, indptrs, curdex, curptr); // big jump to zero but no match.
+        EXPECT_EQ(curdex, 3);
+        EXPECT_EQ(curptr, 5);
+    }
+
+    {
+        int curdex = 19;
+        size_t curptr = 16;
+        test.search_below(0, 2, indices, indptrs, curdex, curptr); // big jump to zero, with a match.
+        EXPECT_EQ(curdex, 0);
+        EXPECT_EQ(curptr, 11);
+    }
+}
+
+TEST(SecondaryExtractionWorkspaceBase, Duplicated) {
+    struct DuplicatedModifier {
+        static void increment(size_t& ptr, const std::vector<int>& indices, size_t limit) {
+            auto current = indices[ptr];
+            while (ptr < limit && indices[ptr] == current) { ++ptr; }
+        }
+
+        static void decrement(size_t& ptr, const std::vector<int>& indices, size_t limit) {
+            if (ptr != limit) {
+                --ptr;
+                auto current = indices[ptr];
+                while (ptr > limit && indices[ptr - 1] == current) {
+                    --ptr;
+                }
+            }
+        }
+
+        static size_t get(const size_t& ptr) { return ptr; }
+
+        static void set(size_t& ptr, size_t val) { ptr = val; }
+    };
+
+    tatami::sparse::SecondaryExtractionWorkspaceBase<int, DuplicatedModifier> test(19);
+
+    std::vector<int> indices {
+        0, 0, 0, 2, 6, 6, 9, 10, 15, 15, 15, 
+        1, 1, 3, 3, 3, 5, 8, 8, 8, 11, 14, 18, 18, 18,
+        2, 4, 7, 7, 8, 8, 12, 13, 15
+    };
+
+    std::vector<size_t> indptrs {
+        0,
+        11,
+        25,
+        34
+    };
+
+    // Increment works correctly.
+    {
+        int curdex = 0;
+        size_t curptr = 0;
+        test.search_above(0, 0, indices, indptrs, curdex, curptr); // no-op.
+        EXPECT_EQ(curdex, 0);
+        EXPECT_EQ(curptr, 0);
+
+        test.search_above(1, 0, indices, indptrs, curdex, curptr); // increment to next lower bound.
+        EXPECT_EQ(curdex, 2);
+        EXPECT_EQ(curptr, 3);
+
+        test.search_above(2, 0, indices, indptrs, curdex, curptr); // no-op.
+        EXPECT_EQ(curdex, 2);
+        EXPECT_EQ(curptr, 3);
+
+        test.search_above(7, 0, indices, indptrs, curdex, curptr); // big jump.
+        EXPECT_EQ(curdex, 9);
+        EXPECT_EQ(curptr, 6);
+
+        test.search_above(15, 0, indices, indptrs, curdex, curptr); // another big jump.
+        EXPECT_EQ(curdex, 15);
+        EXPECT_EQ(curptr, 8);
+    }
+
+    {
+        int curdex = 0;
+        size_t curptr = 11;
+        test.search_above(10, 1, indices, indptrs, curdex, curptr); // jumps work correctly.
+        EXPECT_EQ(curdex, 11);
+        EXPECT_EQ(curptr, 20);
+
+        test.search_above(18, 1, indices, indptrs, curdex, curptr); // jump to end works correctly.
+        EXPECT_EQ(curdex, 18);
+        EXPECT_EQ(curptr, 22);
+    }
+
+    // Decrement works correctly.
+    {
+        int curdex = 19;
+        size_t curptr = 34;
+        test.search_below(16, 2, indices, indptrs, curdex, curptr); // no-op.
+        EXPECT_EQ(curdex, 19);
+        EXPECT_EQ(curptr, 34);
+
+        test.search_below(15, 2, indices, indptrs, curdex, curptr); // decrement.
+        EXPECT_EQ(curdex, 15);
+        EXPECT_EQ(curptr, 33);
+
+        test.search_below(8, 2, indices, indptrs, curdex, curptr); // big jump.
+        EXPECT_EQ(curdex, 8);
+        EXPECT_EQ(curptr, 29);
+
+        test.search_below(7, 2, indices, indptrs, curdex, curptr); // decrement.
+        EXPECT_EQ(curdex, 7);
+        EXPECT_EQ(curptr, 27);
+
+        test.search_below(0, 2, indices, indptrs, curdex, curptr); // jump to zero.
+        EXPECT_EQ(curdex, 2);
+        EXPECT_EQ(curptr, 25);
+    }
+}


### PR DESCRIPTION
- [ ] Primary jumps with caching.
- [x] Add dedicated tests for the sparse secondary classes.
- [x] Add dedicated tests for semi-compressed jumps to end, which have tricky decrements.