### PR TITLE
Improved perf for reverse iteration in secondary sparse extractor.

### DIFF
--- a/tests/src/sparse/CompressedSparseSecondaryExtractorBasic.cpp
+++ b/tests/src/sparse/CompressedSparseSecondaryExtractorBasic.cpp
@@ -224,6 +224,18 @@ TEST(SecondaryExtractionWorkspaceBase, Decrement) {
 
         EXPECT_FALSE(test.search(6, n, identity, indices2, indptrs, store_fun, skip_fun)); 
         EXPECT_FALSE(test.search(5, n, identity, indices2, indptrs, store_fun, skip_fun));
+
+        EXPECT_TRUE(test.search(4, n, identity, indices2, indptrs, store_fun, skip_fun)); 
+        expected = std::vector<int>{ -1, 6, 13 };
+        EXPECT_EQ(results, expected);
+
+        EXPECT_TRUE(test.search(2, n, identity, indices2, indptrs, store_fun, skip_fun)); 
+        expected = std::vector<int>{ 0, -1, -1 };
+        EXPECT_EQ(results, expected);
+
+        EXPECT_TRUE(test.search(0, n, identity, indices2, indptrs, store_fun, skip_fun)); 
+        expected = std::vector<int>{ -1, -1, 11 };
+        EXPECT_EQ(results, expected);
     }
 }
 


### PR DESCRIPTION
This mostly involves using a dedicated "fail flag" of -1 for the index below the 
current position when the position is already at the start of the primary dimension.