### PR TITLE
Add Support for 19 Unary Math Functions

### DIFF
--- a/include/tatami/isometric/unary/math_helpers.hpp
+++ b/include/tatami/isometric/unary/math_helpers.hpp
@@ -59,6 +59,52 @@ public:
 };
 
 /**
+ * @brief Take the signum of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedSignHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = (T(0) < buffer[i]) - (buffer[i] < T(0));
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
  * @brief Take the logarithm of a matrix entry.
  * 
  * @tparam Base_ Numeric type for the log base.
@@ -142,6 +188,144 @@ private:
     void core (Index_ length, Value_* buffer) const {
         for (Index_ i = 0; i < length; ++i) {
             buffer[i] = std::sqrt(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the ceiling of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedCeilingHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::ceil(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the floor of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedFloorHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::floor(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the trunc of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedTruncHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::trunc(buffer[i]);
         }
     }
 
@@ -312,6 +496,706 @@ public:
                 buffer[i] = 1;
             }
         }
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Use a matrix entry as an exponent minus 1.
+ */
+template<typename T = double>
+struct DelayedExpm1Helper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::expm1(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the arc cosine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAcosHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::acos(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the inverse hyperbolic cosine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAcoshHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::acosh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the arc sine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAsinHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::asin(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the inverse hyperbolic sine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAsinhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::asinh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the arc tangent of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAtanHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::atan(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the inverse hyperbolic tangent of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAtanhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::atanh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the cosine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedCosHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::cos(buffer[i]);
+        }
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            if (buffer[i]) {
+                buffer[i] = std::cos(buffer[i]);
+            } else {
+                buffer[i] = 1;
+            }
+        }
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the hyperbolic cosine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedCoshHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::cosh(buffer[i]);
+        }
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            if (buffer[i]) {
+                buffer[i] = std::cosh(buffer[i]);
+            } else {
+                buffer[i] = 1;
+            }
+        }
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the sine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedSinHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::sin(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the hyperbolic sine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedSinhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::sinh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the tangent of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedTanHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::tan(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the hyperbolic tangent of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedTanhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::tanh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the gamma of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedGammaHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::tgamma(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the logarithm of the gamma of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedLgammaHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::lgamma(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
     }
     /**
      * @endcond

--- a/include/tatami/isometric/unary/math_helpers.hpp
+++ b/include/tatami/isometric/unary/math_helpers.hpp
@@ -471,11 +471,6 @@ public:
      * @endcond
      */
 
-private:
-    template<typename Value_, typename Index_>
-    void core (Index_ length, Value_* buffer) const {
-    }
-
 public:
     /**
      * @cond
@@ -844,11 +839,6 @@ public:
      * @endcond
      */
 
-private:
-    template<typename Value_, typename Index_>
-    void core (Index_ length, Value_* buffer) const {
-    }
-
 public:
     /**
      * @cond
@@ -894,11 +884,6 @@ public:
     /**
      * @endcond
      */
-
-private:
-    template<typename Value_, typename Index_>
-    void core (Index_ length, Value_* buffer) const {
-    }
 
 public:
     /**

--- a/include/tatami/isometric/unary/math_helpers.hpp
+++ b/include/tatami/isometric/unary/math_helpers.hpp
@@ -82,7 +82,7 @@ private:
     template<typename Value_, typename Index_>
     void core (Index_ length, Value_* buffer) const {
         for (Index_ i = 0; i < length; ++i) {
-            buffer[i] = (T(0) < buffer[i]) - (buffer[i] < T(0));
+            buffer[i] = (static_cast<T>(0) < buffer[i]) - (buffer[i] < static_cast<T>(0));
         }
     }
 

--- a/include/tatami/isometric/unary/math_helpers.hpp
+++ b/include/tatami/isometric/unary/math_helpers.hpp
@@ -59,7 +59,7 @@ public:
 };
 
 /**
- * @brief Take the signum of a matrix entry.
+ * @brief Take the sign of a matrix entry.
  */
 template<typename T = double>
 struct DelayedSignHelper {

--- a/include/tatami/isometric/unary/math_helpers.hpp
+++ b/include/tatami/isometric/unary/math_helpers.hpp
@@ -82,7 +82,9 @@ private:
     template<typename Value_, typename Index_>
     void core (Index_ length, Value_* buffer) const {
         for (Index_ i = 0; i < length; ++i) {
-            buffer[i] = (static_cast<T>(0) < buffer[i]) - (buffer[i] < static_cast<T>(0));
+            if (!std::isnan(buffer[i])) {
+                buffer[i] = (static_cast<Value_>(0) < buffer[i]) - (buffer[i] < static_cast<Value_>(0));
+            }
         }
     }
 

--- a/tests/src/isometric/unary/math_helpers.cpp
+++ b/tests/src/isometric/unary/math_helpers.cpp
@@ -52,6 +52,33 @@ TEST_F(MathTest, Abs) {
     tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
 }
 
+TEST_F(MathTest, SignByColumn) {
+    tatami::DelayedSignHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = (0 < r) - (r < 0);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
 TEST_F(MathTest, SqrtByColumn) {
     tatami::DelayedAbsHelper op0;
     auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
@@ -239,6 +266,33 @@ TEST_F(MathTest, ExpByColumn) {
     tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
 }
 
+TEST_F(MathTest, Expm1ByColumn) {
+    tatami::DelayedExpm1Helper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::expm1(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
 TEST_F(MathTest, RoundByColumn) {
     tatami::DelayedRoundHelper op;
     auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
@@ -252,6 +306,493 @@ TEST_F(MathTest, RoundByColumn) {
     auto refvec = simulated;
     for (auto& r : refvec) {
         r = std::round(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, CeilingByColumn) {
+    tatami::DelayedCeilingHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::ceil(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, FloorByColumn) {
+    tatami::DelayedFloorHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::floor(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, TruncByColumn) {
+    tatami::DelayedTruncHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::trunc(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, SinByColumn) {
+    tatami::DelayedSinHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::sin(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, CosByColumn) {
+    tatami::DelayedCosHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_FALSE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::cos(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, TanByColumn) {
+    tatami::DelayedTanHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::tan(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, AsinByColumn) {
+    double CONSTANT = 10;
+    auto op0 = tatami::make_DelayedDivideScalarHelper<true>(CONSTANT);
+    auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
+    auto sparse_mod0 = tatami::make_DelayedUnaryIsometricOp(sparse, op0);
+
+    tatami::DelayedAsinHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense_mod0, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse_mod0, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::asin(r / CONSTANT);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, AcosByColumn) {
+    double CONSTANT = 10;
+    auto op0 = tatami::make_DelayedDivideScalarHelper<true>(CONSTANT);
+    auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
+    auto sparse_mod0 = tatami::make_DelayedUnaryIsometricOp(sparse, op0);
+
+    tatami::DelayedAcosHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense_mod0, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse_mod0, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_FALSE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::acos(r / CONSTANT);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, AtanByColumn) {
+    tatami::DelayedAtanHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::atan(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, SinhByColumn) {
+    tatami::DelayedSinhHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::sinh(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, CoshByColumn) {
+    tatami::DelayedCoshHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_FALSE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::cosh(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, TanhByColumn) {
+    tatami::DelayedTanhHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::tanh(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, AsinhByColumn) {
+    tatami::DelayedAsinhHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::asinh(r);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, AcoshByColumn) {
+    double CONSTANT = 11;
+    auto op0 = tatami::make_DelayedAddScalarHelper<double>(CONSTANT);
+    auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
+    auto sparse_mod0 = tatami::make_DelayedUnaryIsometricOp(sparse, op0);
+
+    tatami::DelayedAcoshHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense_mod0, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse_mod0, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_FALSE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::acosh(r + CONSTANT);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, AtanhByColumn) {
+    double CONSTANT = 10;
+    auto op0 = tatami::make_DelayedDivideScalarHelper<true>(CONSTANT);
+    auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
+    auto sparse_mod0 = tatami::make_DelayedUnaryIsometricOp(sparse, op0);
+
+    tatami::DelayedAtanhHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense_mod0, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse_mod0, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_TRUE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::atanh(r / CONSTANT);
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, GammaByColumn) {
+    tatami::DelayedAbsHelper op0;
+    auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
+    auto sparse_mod0 = tatami::make_DelayedUnaryIsometricOp(sparse, op0);
+
+    tatami::DelayedGammaHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense_mod0, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse_mod0, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_FALSE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::tgamma(std::abs(r));
+    }
+    tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
+
+    // Again, doing some light tests.
+    bool FORWARD = true;
+    int JUMP = 1;
+
+    tatami_test::test_simple_column_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_column_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+
+    tatami_test::test_simple_row_access(dense_mod.get(), &ref, FORWARD, JUMP);
+    tatami_test::test_simple_row_access(sparse_mod.get(), &ref, FORWARD, JUMP);
+}
+
+TEST_F(MathTest, LgammaByColumn) {
+    tatami::DelayedAbsHelper op0;
+    auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
+    auto sparse_mod0 = tatami::make_DelayedUnaryIsometricOp(sparse, op0);
+
+    tatami::DelayedLgammaHelper op;
+    auto dense_mod = tatami::make_DelayedUnaryIsometricOp(dense_mod0, op);
+    auto sparse_mod = tatami::make_DelayedUnaryIsometricOp(sparse_mod0, op);
+
+    EXPECT_FALSE(dense_mod->sparse());
+    EXPECT_FALSE(sparse_mod->sparse());
+    EXPECT_EQ(dense->nrow(), dense_mod->nrow());
+    EXPECT_EQ(dense->ncol(), dense_mod->ncol());
+
+    auto refvec = simulated;
+    for (auto& r : refvec) {
+        r = std::lgamma(std::abs(r));
     }
     tatami::DenseRowMatrix<double> ref(nrow, ncol, std::move(refvec));
 

--- a/tests/src/isometric/unary/math_helpers.cpp
+++ b/tests/src/isometric/unary/math_helpers.cpp
@@ -114,7 +114,8 @@ TEST_F(MathTest, LogByColumn) {
     tatami::DelayedAbsHelper op0;
     auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
     auto sparse_mod0 = tatami::make_DelayedUnaryIsometricOp(sparse, op0);
-    
+
+    // Test log(abs(x) + 5).
     double CONSTANT = 5;
     auto op1 = tatami::make_DelayedAddScalarHelper<double>(CONSTANT);
     auto dense_mod1 = tatami::make_DelayedUnaryIsometricOp(dense_mod0, op1);
@@ -483,6 +484,7 @@ TEST_F(MathTest, TanByColumn) {
 }
 
 TEST_F(MathTest, AsinByColumn) {
+    // Divide simulated values in [-10, 10] by 10 for domain [-1, 1].
     double CONSTANT = 10;
     auto op0 = tatami::make_DelayedDivideScalarHelper<true>(CONSTANT);
     auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
@@ -515,6 +517,7 @@ TEST_F(MathTest, AsinByColumn) {
 }
 
 TEST_F(MathTest, AcosByColumn) {
+    // Divide simulated values in [-10, 10] by 10 for domain [-1, 1].
     double CONSTANT = 10;
     auto op0 = tatami::make_DelayedDivideScalarHelper<true>(CONSTANT);
     auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
@@ -682,6 +685,7 @@ TEST_F(MathTest, AsinhByColumn) {
 }
 
 TEST_F(MathTest, AcoshByColumn) {
+    // Add 11 to simulated values in [-10, 10] for domain >= 1.
     double CONSTANT = 11;
     auto op0 = tatami::make_DelayedAddScalarHelper<double>(CONSTANT);
     auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);
@@ -714,6 +718,7 @@ TEST_F(MathTest, AcoshByColumn) {
 }
 
 TEST_F(MathTest, AtanhByColumn) {
+    // Divide simulated values in [-10, 10] by 10 for domain [-1, 1].
     double CONSTANT = 10;
     auto op0 = tatami::make_DelayedDivideScalarHelper<true>(CONSTANT);
     auto dense_mod0 = tatami::make_DelayedUnaryIsometricOp(dense, op0);


### PR DESCRIPTION
Add support for 19 unary math functions using 18 functions from C++ standard library plus 1 trial function. The 18 functions from C++ standard library are: `std::ceil`, `std::floor`, `std::trunc`, `std::acos`, `std::acosh`, `std::asin`, `std::asinh`, `std::atan`, `std::atanh`, `std::expm1`, `std::cos`, `std::cosh`, `std::sin`, `std::sinh`, `std::tan`, `std::tanh`, `std::tgamma`, `std::lgamma`. The one trivial function is the signum function.